### PR TITLE
Add activity completion notification

### DIFF
--- a/app/core/companion.py
+++ b/app/core/companion.py
@@ -461,7 +461,7 @@ class RealisticAICompanion:
 
                 if changes["activity_ended"]:
                     activity = changes["activity_ended"]
-                    await self._notify_activity_end(activity)
+                    await self.virtual_life._notify_activity_end(activity)
 
         except Exception as e:
             self.logger.error(f"Ошибка обновления виртуальной жизни: {e}")

--- a/app/core/virtual_life.py
+++ b/app/core/virtual_life.py
@@ -266,9 +266,20 @@ class VirtualLifeManager:
                 """, (activity_id,))
                 
                 conn.commit()
-                
+
         except Exception as e:
             self.logger.error(f"Ошибка завершения активности: {e}")
+
+    async def _notify_activity_end(self, activity: VirtualActivity):
+        """Отправляет уведомление о завершении активности"""
+        messages = [
+            f"Я закончила {activity.description}.",
+            "Теперь я свободна пообщаться!",
+        ]
+
+        # Для простоты пока выводим уведомление в лог
+        for msg in messages:
+            self.logger.info(msg)
     
     def get_current_context_for_ai(self) -> str:
         """Возвращает контекст текущей активности для AI"""


### PR DESCRIPTION
## Summary
- log a multi-message notification when a scheduled activity ends
- trigger the new notification in `update_virtual_life`

## Testing
- `python -m py_compile app/core/virtual_life.py app/core/companion.py`

------
https://chatgpt.com/codex/tasks/task_e_68456af2e9ac832686e1bed7c3614076