### PR TITLE
Populate schedule at startup

### DIFF
--- a/app/core/companion.py
+++ b/app/core/companion.py
@@ -934,7 +934,10 @@ class RealisticAICompanion:
     async def start(self):
         """Запуск компаньона"""
         self.logger.info("Реалистичный AI-компаньон с многосообщенческими ответами запущен")
-        
+
+        # Создаем расписание виртуальной жизни один раз при запуске
+        await self.create_automatic_schedule()
+
         while True:
             await asyncio.sleep(1)
     


### PR DESCRIPTION
## Summary
- populate the virtual life schedule when the companion starts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684570df98d083268c4ff22c9d8fea50