### PR TITLE
Add virtual life context to AI system prompt

### DIFF
--- a/app/core/ai_client.py
+++ b/app/core/ai_client.py
@@ -240,9 +240,16 @@ class OptimizedAI:
         
         logging.info(f"Генерация ответа для {character_name}, тип вопроса: {question_type}")
         
-        if hasattr(self, 'virtual_life_manager'):
+        # Добавляем сведения о текущей виртуальной жизни, если менеджер доступен
+        virtual_context = None
+        if getattr(self, 'virtual_life_manager', None):
+            try:
                 virtual_context = self.virtual_life_manager.get_current_context_for_ai()
-                context['virtual_life_context'] = virtual_context
+            except Exception as e:
+                logging.error(f"Ошибка получения контекста виртуальной жизни: {e}")
+
+        if virtual_context:
+            context['virtual_life_context'] = virtual_context
 
         # Строим промпт с учётом персонажа
         system_prompt = self._build_character_system_prompt(context)


### PR DESCRIPTION
## Summary
- fetch virtual life context in `generate_split_response`
- pass context to system prompt for activity-aware replies

## Testing
- `python scripts/test_dbconn.py 2>&1 | tail -n 20`
- `python scripts/test_multi_messages.py 2>&1 | tail -n 20` (fails: ModuleNotFoundError)

------
https://chatgpt.com/codex/tasks/task_e_68457200f5fc8326a0154cc541ff5a3f