### PR TITLE
Add memory clearing command

### DIFF
--- a/app/database/memory_manager.py
+++ b/app/database/memory_manager.py
@@ -356,10 +356,30 @@ class DatabaseMemoryManager:
                     })
                 
                 return results
-                
+
         except Exception as e:
             self.logger.error(f"Ошибка получения диалогов: {e}")
             return []
+
+    def clear_all_data(self):
+        """Удаляет все диалоги и воспоминания текущего персонажа"""
+        try:
+            with self.get_db_connection() as conn:
+                cursor = conn.cursor()
+
+                cursor.execute(
+                    "DELETE FROM conversations WHERE character_id = ?",
+                    (self.character_id,)
+                )
+                cursor.execute(
+                    "DELETE FROM memories WHERE character_id = ?",
+                    (self.character_id,)
+                )
+
+                conn.commit()
+        except Exception as e:
+            self.logger.error(f"Ошибка очистки данных: {e}")
+            raise
 
     def build_context_for_prompt(self, current_message: str) -> str:
         """Создание контекста с учётом консолидированной памяти"""
@@ -451,3 +471,10 @@ class EnhancedMemorySystem:
                 "total_memories": 0,
                 "last_conversation": None
             }
+
+    def clear_all_data(self):
+        """Удаляет все данные текущего персонажа"""
+        try:
+            self.db_manager.clear_all_data()
+        except Exception as e:
+            self.logger.error(f"Ошибка очистки данных: {e}")

--- a/app/integrations/telegram_bot.py
+++ b/app/integrations/telegram_bot.py
@@ -65,7 +65,8 @@ class TelegramCompanion(RealisticAICompanion):
             self.app.add_handler(CommandHandler("mood", self.mood_command))
             self.app.add_handler(CommandHandler("memories", self.memories_command))
             self.app.add_handler(CommandHandler("stats", self.stats_command))
-            self.app.add_handler(CommandHandler("dbcheck", self.dbcheck_command))        
+            self.app.add_handler(CommandHandler("dbcheck", self.dbcheck_command))
+            self.app.add_handler(CommandHandler("clearmem", self.clear_memory_command))
 
         # Обработка текстовых сообщений
         self.app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self.handle_message))
@@ -477,6 +478,17 @@ class TelegramCompanion(RealisticAICompanion):
             status_text = f"❌ Ошибка проверки БД: {e}"
         
         await update.message.reply_text(status_text, parse_mode='Markdown')
+
+    async def clear_memory_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
+        """Полная очистка данных о пользователе"""
+        if not self.commands_enabled:
+            return
+
+        try:
+            self.enhanced_memory.clear_all_data()
+            await update.message.reply_text("🗑️ Память очищена")
+        except Exception as e:
+            await update.message.reply_text(f"❌ Ошибка очистки памяти: {e}")
 
     async def start_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         """Обработка команды /start"""


### PR DESCRIPTION
## Summary
- support clearing all character data from the DB
- expose clearing function on `EnhancedMemorySystem`
- register `/clearmem` command in Telegram bot
- implement `/clearmem` handler to purge memory

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q app`

------
https://chatgpt.com/codex/tasks/task_e_684603c5cce483268a4bddcd89807561