### PR TITLE
Refactor imports to rely on package install

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ venv\Scripts\activate     # Windows
 
 # Устанавливаем зависимости
 pip install -r requirements.txt
+
+# Устанавливаем пакет в режиме разработки (или добавьте путь в PYTHONPATH)
+pip install -e .
 ```
 
 ### 4. Запуск

--- a/app/core/companion.py
+++ b/app/core/companion.py
@@ -5,18 +5,13 @@ import asyncio
 import json
 import logging
 import random
-import sys
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Optional, Dict, Any, List
 from openai import AsyncOpenAI
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
 from .virtual_life import VirtualLifeManager, VirtualActivity
-
-# Добавляем корневой путь в sys.path ОДИН РАЗ
-sys.path.append(str(Path(__file__).parent.parent.parent))
 
 # Относительные импорты для модулей внутри core
 from .psychology import PsychologicalCore
@@ -30,8 +25,8 @@ from .memory_consolidation import (
     enhance_existing_memories_with_emotions,
 )
 
-# Абсолютный импорт для database (так как sys.path добавлен)
-from app.database.memory_manager import EnhancedMemorySystem
+# Импорт системы работы с базой данных
+from ..database.memory_manager import EnhancedMemorySystem
 
 
 class RealisticAICompanion:

--- a/main.py
+++ b/main.py
@@ -6,10 +6,6 @@ import json
 import logging
 import os
 import sys
-from pathlib import Path
-
-# Добавляем путь к app в PYTHONPATH
-sys.path.append(str(Path(__file__).parent))
 
 from app.integrations.telegram_bot import TelegramCompanion
 from app.core.companion import RealisticAICompanion

--- a/scripts/run_demo.py
+++ b/scripts/run_demo.py
@@ -3,12 +3,7 @@
 """
 
 import asyncio
-import sys
 import json
-from pathlib import Path
-
-# Добавляем корневую директорию в PYTHONPATH
-sys.path.append(str(Path(__file__).parent.parent))
 
 from app.core.companion import RealisticAICompanion
 

--- a/scripts/setup_db.py
+++ b/scripts/setup_db.py
@@ -4,10 +4,6 @@
 
 import sys
 import os
-from pathlib import Path
-
-# Добавляем корневую директорию в PYTHONPATH
-sys.path.append(str(Path(__file__).parent.parent))
 
 from app.database import init_database
 

--- a/scripts/test_dbconn.py
+++ b/scripts/test_dbconn.py
@@ -5,14 +5,9 @@
 """
 
 import asyncio
-import sys
 import os
 import sqlite3
 import time
-from pathlib import Path
-
-# Добавляем корневую директорию в PYTHONPATH
-sys.path.append(str(Path(__file__).parent.parent))
 
 async def test_database():
     """Тестирование базы данных"""
@@ -91,9 +86,8 @@ async def test_memory_system():
     print("\n🧠 Тестирование системы памяти...")
     
     try:
-        # Импортируем исправленную систему памяти
-        sys.path.append(str(Path(__file__).parent.parent / 'app'))
-        from database.memory_manager import EnhancedMemorySystem
+        # Импортируем систему памяти из пакета
+        from app.database.memory_manager import EnhancedMemorySystem
         
         memory = EnhancedMemorySystem()
         
@@ -129,9 +123,8 @@ async def test_message_splitting():
     print("\n✂️ Тестирование разделения сообщений...")
     
     try:
-        # Импортируем исправленный AI клиент
-        sys.path.append(str(Path(__file__).parent.parent / 'app'))
-        from core.ai_client import OptimizedAI
+        # Импортируем AI клиент из пакета
+        from app.core.ai_client import OptimizedAI
         
         # Мок конфигурация
         config = {
@@ -171,8 +164,7 @@ async def test_question_analysis():
     print("\n🎯 Тестирование анализа вопросов...")
     
     try:
-        sys.path.append(str(Path(__file__).parent.parent / 'app'))
-        from core.ai_client import OptimizedAI
+        from app.core.ai_client import OptimizedAI
         
         config = {
             'ai': {'model': 'test', 'max_tokens': 300, 'temperature': 0.8},
@@ -243,8 +235,7 @@ async def test_database_integration():
     print("\n🔗 Тестирование интеграции с БД...")
     
     try:
-        sys.path.append(str(Path(__file__).parent.parent / 'app'))
-        from database.memory_manager import DatabaseMemoryManager
+        from app.database.memory_manager import DatabaseMemoryManager
         
         # Создаем менеджер БД
         db_manager = DatabaseMemoryManager()

--- a/scripts/test_multi_messages.py
+++ b/scripts/test_multi_messages.py
@@ -3,12 +3,7 @@
 """
 
 import asyncio
-import sys
 import json
-from pathlib import Path
-
-# Добавляем корневую директорию в PYTHONPATH
-sys.path.append(str(Path(__file__).parent.parent))
 
 from app.core.companion import RealisticAICompanion
 from app.core.typing_simulator import TypingSimulator

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="aicompanion",
+    version="0.1.0",
+    packages=find_packages(include=["app", "app.*"]),
+)


### PR DESCRIPTION
## Summary
- remove `sys.path.append` usage
- import modules via package-relative paths
- add `setup.py` so the project can be installed with `pip -e .`
- document editable install step in README

## Testing
- `pip install --quiet -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467bc370488326b6903e15c466ec25